### PR TITLE
Easier support multiple serial ports, minor bug fixes and log writing additions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,23 @@
+
+v1.4.5 - 05/04/14 - Ron Curry, InSyte Technologies 
+	- ser2sock - Rewrote init.d script to easily accomodate multiple instances           
+	and added additional error checking and reporting.
+	- ser2sock.c - Added "-P" option to allow optionally specify PID pathname
+	  to better support running mulitple instantiations via scripts.        
+	  Prior to this  ser2sock would simply overwrite any previous PID file in
+	  /var/run
+	- ser2sock.c - Added code to delete PID file apon exit
+	- ser2sock.c - Changed logic which caused reading of a potentially non-
+	  existent default config file prior to reading command line arguments          
+	  and prior to a specified config and fixed error reporting.
+	  Now it only read the correct file once after considering cmdline args
+	- ser2sock.c - Added "PID_FILE" keyword/option to config file support
+	  Not needed for current init.d support but may be useful to some
+	- Added trivial code to delete the /var/run/<PID_FILE> upon exit.
+	- ser2sock.c - Added several additional syslog write to aid in debugging
+	- ser2sock.c - Changed ser2sock version to 1.4.5 to reflect above changes
+	  Version 1.4.5 should remain fully compatible with 1.4.4 behaviour
+
 v1.4.4 - 10/25/13
     Refactored main state machine, logging, cleanup.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ser2sock - Serial to Socket Redirector
 The ser2sock utility allows sharing of a serial device over a TCP/IP
 network.  It also supports encryption and authentication via OpenSSL.
 
+05/04/14 Version 1.4.5 adds better support for running more than one copy at a time
+on Linux system. init.d script rewritten to provide easy configuration for
+multiple instantiations and modifications to ser2sock.c to correct PID file
+creation/deletion behavior consistent with running more than one instantiation.
 
 Installation
 ============
@@ -18,6 +22,7 @@ NOTE: The OpenSSL dev package is needed in order to compile with SSL support.
 7. sudo cp init/ser2sock /etc/init.d/
 8. sudo update-rc.d ser2sock defaults
 9. sudo /etc/init.d/ser2sock start
+10. To run more than one instantiation follow instructions in the init/ser2sock script
 
 Usage
 =====
@@ -26,7 +31,7 @@ Usage
 Usage: ./ser2sock -p <socket listen port> -s <serial port dev>
 
   -h, -help                 display this help and exit
-  -f <config path>          override config file path
+  -f <config pathname>      override config file pathname
   -p port                   socket port to listen on
   -s <serial device>        serial device; ex /dev/ttyUSB0
 options
@@ -35,11 +40,30 @@ options
   -d                        daemonize
   -0                        raw device mode no !SER2SOCK info messages
   -t                        send terminal init string
+  -P <PID file pathname>    overide default PID file pathname. (for use by init.d script)
   -g                        debug level 0-3
   -c                        keep incoming connections when a serial device is disconnected
   -w milliseconds           delay between attempts to open a serial device (5000)
   -e                        use SSL to encrypt the connection
 ```
+
+Using with more than one serial port (multiple daemon)
+======================================================
+
+1. Follow basic installation instructions above.
+2. Make an additional copy of the /etc/init.d/ser2sock scrip for each serial
+   port you wish to use but use a unique filename such as /etc/init.d/ser2sock.1 ,
+   ser2sock.2 , etc.
+3. Edit each file and change the "Provides:" line to use the same name that you
+   gave the file: ser2sock.1 (for example)
+4. Create a new configuration file in /etc/ser2sock using the same name that you
+   gave the init.d script for the corresponding port: ser2sock.1.conf (example)
+5. Edit each of those files to reflect the serial device you are using and the
+   network port it can be accessed through. Make sure it's a different port from
+   the other instantiations and unused by anything else.
+5. For each new port do: sudo update-rc.d <script filename> defaults
+6. For each new port do: sudo /ect/init.d/<script filename> start
+
 
 Authentication via SSL
 ======================

--- a/init/ser2sock
+++ b/init/ser2sock
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # SER2SOCK
 
 ### BEGIN INIT INFO
@@ -9,20 +8,37 @@
 # Required-Stop: $remote_fs
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
-# Short-Description: init script for ser2sock
+# Short-Description: init script for ser2sock instantiation
 # Description: This is the initialization script for ser2sock.
 #
 ### END INIT INFO
 
-PORT=10000
-DEVICE=/dev/ttyAMA0
-BAUD=115200
 
-CONF=/etc/ser2sock/ser2sock.conf
+### Customization Instructions
+# 1. Change line 2 to the name you'll be using for this script
+# 2. Change the "Provides:" line to use the same name
+# 3. Save this new script using the new name
+# 4. Create a configuration file in /etc/ser2sock using 
+#    the script name: <script filename>.conf
+# 5. sudo cp <script filepath> /etc/init.d/
+# 6. sudo update-rc.d <script filename> defaults
+# 7. sudo /ect/init.d/<script filename> start
 
-ser2sock=/usr/local/bin/ser2sock
-prog=ser2sock
+
+### -----NO MODIFICATIONS REQUIRED BELOW THIS LINE------
+
+# Change this only if your executable has a different name
+PROGRAM_NAME="ser2sock"
+
+# Use the name of this script as the SCRIPT_NAME
+SCRIPT_NAME=${0##*/}
+
+CONF_FILE="/etc/ser2sock/${SCRIPT_NAME}.conf"
+EXECUTABLE="/usr/local/bin/${PROGRAM_NAME}"
+PID_FILE="/var/run/${SCRIPT_NAME}.pid"
+DAEMON_ARGS="-f ${CONF_FILE} -P ${PID_FILE}"
 RETVAL=0
+
 
 BOLD=$(tput bold)
 GREEN=$(tput setaf 2)
@@ -30,30 +46,56 @@ RED=$(tput setaf 1)
 NORMAL=$(tput sgr0)
 
 start() {
-    echo -n $"Starting $prog: "
+    echo
+    echo $"Starting instantiation ${BOLD}${SCRIPT_NAME}${NORMAL} of ${BOLD}${PROGRAM_NAME}${NORMAL}..."
+    echo
+    echo "Script name       : $SCRIPT_NAME"
+    echo "Executable file   : $EXECUTABLE"
+    echo "Arguments         : $DAEMON_ARGS"
+    echo "Configuration file: $CONF_FILE"
+    echo "PID file          : $PID_FILE"
+    echo
 
-    if [ ! -f $CONF ]; then
-        $ser2sock -d -c -p $PORT -s $DEVICE -b 115200 >/dev/null 2>&1
-    else
-        $ser2sock -d >/dev/null 2>&1
-    fi
+    start-stop-daemon --start  --pidfile $PID_FILE --exec $EXECUTABLE -- \
+        $DAEMON_ARGS >/dev/nul 2>&1
     RETVAL=$?
 
     if [ $RETVAL = 0 ]; then
-        echo "${BOLD}${GREEN}done${NORMAL}"
+        echo $"${BOLD}${GREEN}Started${NORMAL}"
     else
-        echo $"${BOLD}${RED}failed${NORMAL}"
+        echo $"${BOLD}${RED}Failed to start - Return Value = ${RETVAL}${NORMAL}"
     fi
 
+    echo
     return $RETVAL
 }
 
 stop() {
-    echo $"Stopping $prog.."
+    echo
+    echo $"Stopping instantiation ${BOLD}${SCRIPT_NAME}${NORMAL} of ${BOLD}${PROGRAM_NAME}${NORMAL}..."
+    echo
+    echo "Script name       : $SCRIPT_NAME"
+    echo "Executable file   : $EXECUTABLE"
+    echo "PID file          : $PID_FILE"
+    echo
 
-    killall $ser2sock
+    start-stop-daemon --stop --signal TERM --quiet --retry=TERM/10/KILL/5 --pidfile $PID_FILE \
+	--name $PROGRAM_NAME >/dev/nul 2>&1
     RETVAL=$?
 
+    if [ $RETVAL = 0 ]; then
+        echo $"${BOLD}${GREEN}Stopped${NORMAL}"
+    else 
+        if [ $RETVAL = 1 ]; then
+            echo $"${BOLD}${GREEN}Already stopped - Return Value = ${RETVAL}${NORMAL}"
+        else
+            echo $"${BOLD}${RED}Failed to stop - Return Value = ${RETVAL}${NORMAL}"
+        fi
+    fi
+
+#    rm -f $PID_FILE
+
+    echo
     return $RETVAL
 }
 
@@ -69,7 +111,7 @@ case "$1" in
         start
         ;;
     *)
-        echo $"Usage: $prog {start|stop|restart}"
+        echo $"Usage: $PROG_NAME {start|stop|restart}"
         exit 1
 esac
 


### PR DESCRIPTION
v1.4.5 - 05/04/14 - Ron Curry, InSyte Technologies
    - ser2sock - Rewrote init.d script to easily accomodate multiple
instances
    and added additional error checking and reporting.
    - ser2sock.c - Added "-P" option to allow optionally specify PID
pathname
      to better support running mulitple instantiations via scripts.

```
  Prior to this  ser2sock would simply overwrite any previous PID file
```

in
      /var/run
    - ser2sock.c - Added code to delete PID file apon exit
    - ser2sock.c - Changed logic which caused reading of a potentially non-
      existent default config file prior to reading command line arguments

```
  and prior to a specified config and fixed error reporting.
  Now it only read the correct file once after considering cmdline args
- ser2sock.c - Added "PID_FILE" keyword/option to config file support
  Not needed for current init.d support but may be useful to some
- Added trivial code to delete the /var/run/<PID_FILE> upon exit.
- ser2sock.c - Added several additional syslog write to aid in
```

debugging
    - ser2sock.c - Changed ser2sock version to 1.4.5 to reflect above
changes
      Version 1.4.5 should remain fully compatible with 1.4.4 behavior
