### PR TITLE
fix: reverse order of -lssl and -lcrypto to enable static build

### DIFF
--- a/configure
+++ b/configure
@@ -3760,7 +3760,7 @@ if ${ac_cv_lib_crypto_BIO_pop+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lcrypto  $LIBS"
+LIBS="$LIBS -lcrypto"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -3795,7 +3795,7 @@ if test "x$ac_cv_lib_crypto_BIO_pop" = xyes; then :
 #define HAVE_LIBCRYPTO 1
 _ACEOF
 
-  LIBS="-lcrypto $LIBS"
+  LIBS="$LIBS -lcrypto"
 
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5


### PR DESCRIPTION
The build failed with:

```
#7 4.373 mv -f .deps/ser2sock.Tpo .deps/ser2sock.Po
#7 4.375 gcc  -Wall -O3 -static  -static -o ser2sock ser2sock.o  -lcrypto -lssl
#7 4.803 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(bio_ssl.o): in function `BIO_new_ssl_connect':
#7 4.805 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/bio_ssl.c:445: undefined reference to `BIO_s_connect'
#7 4.806 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_cert.o): in function `ssl_build_cert_chain':
#7 4.809 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_cert.c:849: undefined reference to `X509_verify_cert_error_string'
#7 4.811 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_ciph.o): in function `ssl_cipher_get_evp':
#7 4.811 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_ciph.c:526: undefined reference to `EVP_enc_null'
#7 4.811 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `ssl_start_async_job':
#7 4.811 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:1675: undefined reference to `ASYNC_WAIT_CTX_new'
#7 4.811 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `SSL_CTX_set_default_verify_dir':
#7 4.811 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4055: undefined reference to `X509_LOOKUP_hash_dir'
#7 4.811 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `SSL_free':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:1219: undefined reference to `ASYNC_WAIT_CTX_free'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `ct_extract_ocsp_response_scts':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4707: undefined reference to `OCSP_response_get1_basic'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4711: undefined reference to `OCSP_resp_count'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4712: undefined reference to `OCSP_resp_get0'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4718: undefined reference to `OCSP_SINGLERESP_get1_ext_d2i'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `ssl_validate_ct':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4897: undefined reference to `CT_POLICY_EVAL_CTX_new'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4905: undefined reference to `CT_POLICY_EVAL_CTX_set1_cert'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4906: undefined reference to `CT_POLICY_EVAL_CTX_set1_issuer'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4907: undefined reference to `CT_POLICY_EVAL_CTX_set_shared_CTLOG_STORE'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4908: undefined reference to `CT_POLICY_EVAL_CTX_set_time'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4941: undefined reference to `CT_POLICY_EVAL_CTX_free'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `SSL_get_all_async_fds':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:1631: undefined reference to `ASYNC_WAIT_CTX_get_all_fds'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `SSL_get_changed_async_fds':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:1641: undefined reference to `ASYNC_WAIT_CTX_get_changed_fds'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `SSL_CTX_set_default_verify_paths':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4048: undefined reference to `X509_STORE_set_default_paths'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_lib.o): in function `SSL_CTX_load_verify_locations':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_lib.c:4085: undefined reference to `X509_STORE_load_locations'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(t1_lib.o): in function `ssl_get_auto_dh':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/t1_lib.c:2437: undefined reference to `BN_get_rfc3526_prime_8192'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/t1_lib.c:2439: undefined reference to `BN_get_rfc3526_prime_3072'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(tls_srp.o): in function `SSL_srp_server_param_with_username':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:168: undefined reference to `SRP_Calc_B'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(tls_srp.o): in function `SSL_set_srp_server_param_pw':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:180: undefined reference to `SRP_get_default_gN'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:189: undefined reference to `SRP_create_verifier_BN'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(tls_srp.o): in function `srp_generate_server_master_secret':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:255: undefined reference to `SRP_Verify_A_mod_N'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:257: undefined reference to `SRP_Calc_u'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:259: undefined reference to `SRP_Calc_server_key'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(tls_srp.o): in function `srp_generate_client_master_secret':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:289: undefined reference to `SRP_Verify_B_mod_N'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:290: undefined reference to `SRP_Calc_u'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:305: undefined reference to `SRP_Calc_x'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:306: undefined reference to `SRP_Calc_client_key'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(tls_srp.o): in function `srp_verify_server_param':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:359: undefined reference to `SRP_check_known_gN_param'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(tls_srp.o): in function `SRP_Calc_A_param':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/tls_srp.c:377: undefined reference to `SRP_Calc_A'
#7 4.814 /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: /usr/lib/gcc/x86_64-alpine-linux-musl/8.3.0/../../../../lib/libssl.a(ssl_conf.o): in function `do_store':
#7 4.814 /home/buildozer/aports/main/openssl/src/openssl-1.1.1d/ssl/ssl_conf.c:477: undefined reference to `X509_STORE_load_locations'
#7 4.814 collect2: error: ld returned 1 exit status
#7 4.814 make[1]: *** [Makefile:289: ser2sock] Error 1
#7 4.814 make[1]: Leaving directory '/ser2sock'
#7 4.815 make: *** [Makefile:194: all] Error 2
```

Reproducable with this Docker build:

```Dockerfile
FROM alpine:3.10

ARG VERSION=master

RUN apk --no-cache add \
        git \
        build-base \
        openssl-dev

RUN git clone --depth 1 --branch "${VERSION}" https://github.com/nutechsoftware/ser2sock.git /ser2sock

WORKDIR /ser2sock

RUN ./configure && \
    make \
      CFLAGS="-Wall -O3 -static" \
      LDFLAGS="-static"
```

I googled and found:

> Reverse the order of linking libssl.a and libcrypto.a, and it should solve the problem.

Source: https://github.com/robertdavidgraham/heartleech/issues/19#issuecomment-40780991

I implemented that in this branch and it works, to try:
```Dockerfile
FROM alpine:3.10

ARG VERSION=fix-build

RUN apk --no-cache add \
        git \
        build-base \
        openssl-dev

RUN git clone --depth 1 --branch "${VERSION}" https://github.com/wilmardo/ser2sock.git /ser2sock

WORKDIR /ser2sock

RUN ./configure && \
    make \
      CFLAGS="-Wall -O3 -static" \
      LDFLAGS="-static"
```